### PR TITLE
Blog post featured image now shown in marquee

### DIFF
--- a/wp-content/themes/bebraven/content.php
+++ b/wp-content/themes/bebraven/content.php
@@ -51,7 +51,7 @@ if ( is_home() || $is_press ) {
 	// Display the image above the content, unless it's a blog post:
 	if ( 'post' != $component_format ) {
 		echo $thumb;
-	} 
+	}
 
 	?>
 	<div class="component-content">
@@ -68,8 +68,12 @@ if ( is_home() || $is_press ) {
 		if ( 'post' == $component_format ) { 
 			?>
 			<span class="date"><?php echo bz_get_publish_date(); ?></span>
-			<div class="post-img"><?php echo $thumb;?></div>
-			<?php 
+			<?php // Show the featured image unless we're in single post view (b/c it will be shown in the header instead):
+			if ( !is_single() && has_post_thumbnail() ){ 
+				?>
+				<div class="post-img"><?php echo $thumb; ?></div>
+				<?php 
+			}
 			// and only an excerpt+link if it's one of the posts on a list:
 			if ( is_home() || is_archive() || is_search() || is_404() || $is_press ) { 
 				the_excerpt(); 

--- a/wp-content/themes/bebraven/header.php
+++ b/wp-content/themes/bebraven/header.php
@@ -93,7 +93,19 @@ $is_bio = ('bio' == $component_format);
 				?>
 
 				<section class="component marquee <?php echo $marquee_format; ?>">
-					<?php echo get_the_post_thumbnail( $container_ID, 'marquee' ); ?>
+
+					<?php 
+					if ( is_single() && has_post_thumbnail() ) {
+						// Blog posts with a featured image, but not the blog page that lists them:
+
+						echo get_the_post_thumbnail( $post->ID, 'marquee' );
+
+					} else {
+						// not a blog post with featured image:
+						echo get_the_post_thumbnail( $container_ID, 'marquee' ); 
+					}
+
+					?>
 
 					
 					<div class="marquee-title">


### PR DESCRIPTION
**Before you pull this, run through the instructions below to see what things looked like before the change.**
How to test:
* See that the Blog page (bebraven.org/blog) looks okay. The marquee image at the top should be of Antoinette Martin in a pink shirt on a blue background, and the blog posts listed below it should look as they did before this change.
* Click on a post that has a featured image (e.g. https://bebraven.org/2018/12/20/people-of-braven/). The marquee should now be the post's featured image, not Antoinette.
* The image shouldn't be repeating inside the post.
* All other parts of the site should be unaffected. 
