### PR TITLE
Add a 2-column mosaic style

### DIFF
--- a/wp-content/themes/bebraven/style.css
+++ b/wp-content/themes/bebraven/style.css
@@ -1497,6 +1497,10 @@ body {
 	margin-bottom: 2vw;
 }
 
+[data-bz-columns='2'] .mosaic-element {
+	width: 47vw;
+}
+
 [data-bz-columns='4'] .mosaic-element {
 	width: 23.5vw;
 	height: 16vw;


### PR DESCRIPTION
Ticket: https://bebraven.zendesk.com/agent/tickets/111

Summary: We have 4 sponsors in the Keystone section so we wanted 2 columns here. Looks like the HTML is already set up that way so it's just adding a selector to the CSS.

Screenshot: 

<img width="1415" alt="Screen Shot 2019-09-30 at 9 25 18 AM" src="https://user-images.githubusercontent.com/1382374/65888317-f0efe880-e364-11e9-8b27-fd7a71535574.png">
